### PR TITLE
Delete statement about expert review

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ maintained and really heavy to compile due to its use of procedural macros.
 
 This alternative is `no-std`, uses no proc-macros, a total of ~20 lines unsafe and works on stable Rust, and is miri tested. With a total of less than 300 lines of implementation code, which consists mostly of type and trait wrangling, this crate aims to be a good minimal solution to the problem of self-referential structs.
 
-It has undergone community code review https://users.rust-lang.org/t/experimental-safe-to-use-proc-macro-free-self-referential-structs-in-stable-rust/52775 from seasoned Rust experts.
-
 ### Fast compile times
 
 ```


### PR DESCRIPTION
This statement is technically factual but highly misleading in this context as far as implying endorsement of the crate. As far as I can tell from the linked thread, no seasoned Rust expert has said "yes this crate is sound". Me as one of those experts in the thread basically lost interest after discovering a large number of ways to trigger UB via the safe API.