### PR TITLE
Improve debug implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,14 +575,10 @@ macro_rules! _impl_automatic_derive {
                 fmt: &mut core::fmt::Formatter,
             ) -> core::result::Result<(), core::fmt::Error> {
                 self.with_dependent(|owner, dependent| {
-                    write!(
-                        fmt,
-                        concat!(
-                            stringify!($StructName),
-                            " {{ owner: {:?}, dependent: {:?} }}"
-                        ),
-                        owner, dependent
-                    )
+                    fmt.debug_struct(stringify!($StructName))
+                        .field("owner", owner)
+                        .field("dependent", dependent)
+                        .finish()
                 })
             }
         }

--- a/tests/self_cell.rs
+++ b/tests/self_cell.rs
@@ -568,6 +568,29 @@ fn result_name_hygiene() {
 }
 
 #[test]
+fn debug_impl() {
+    // See https://github.com/Voultapher/self_cell/pull/22
+    let ast_cell = PackedAstCell::new("xyz, abv".into(), |owner| owner.into());
+
+    assert_eq!(
+        format!("{:?}", &ast_cell),
+        "PackedAstCell { owner: \"xyz, abv\", dependent: Ast([\"z, \", \"yz\"]) }"
+    );
+
+    let hash_fmt = r#"PackedAstCell {
+    owner: "xyz, abv",
+    dependent: Ast(
+        [
+            "z, ",
+            "yz",
+        ],
+    ),
+}"#;
+
+    assert_eq!(format!("{:#?}", ast_cell), hash_fmt);
+}
+
+#[test]
 fn share_across_threads() {
     // drop_joined takes &mut self, so that's not a thread concern anyway.
     // And get_or_init_dependent should be as thread compatible as OnceCell.


### PR DESCRIPTION
Use the proper API for `Debug` implementations (comes with e.g. support for `{:#?}` printing as-well this way).