### PR TITLE
Restore compatibility with Rust 1.42

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,28 @@ jobs:
       run: |
         cd benchmarks
         cargo build --release --verbose
+
+  old-rust:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.42.0
+        profile: minimal
+        override: true
+    - name: Run tests
+      run: RUSTFLAGS=--cfg=old_rust cargo test --verbose
+    - name: Run examples
+      run: |
+        cd examples
+        cargo run --verbose --bin fallible_dependent_construction
+        cargo run --verbose --bin lazy_ast
   
   miri:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,8 +353,8 @@ macro_rules! self_cell {
                     joined_void_ptr
                 );
 
-                let owner_ptr: *mut $Owner = core::ptr::addr_of_mut!((*joined_ptr.as_ptr()).owner);
-                let dependent_ptr: *mut $Dependent = core::ptr::addr_of_mut!((*joined_ptr.as_ptr()).dependent);
+                let owner_ptr: *mut $Owner = joined_ptr.as_ptr().cast::<$Owner>();
+                let dependent_ptr: *mut $Dependent = joined_ptr.as_ptr().cast::<u8>().add(JoinedCell::dependent_offset()).cast::<$Dependent>();
 
                 // Move owner into newly allocated space.
                 owner_ptr.write(owner);
@@ -398,8 +398,8 @@ macro_rules! self_cell {
                     joined_void_ptr
                 );
 
-                let owner_ptr: *mut $Owner = core::ptr::addr_of_mut!((*joined_ptr.as_ptr()).owner);
-                let dependent_ptr: *mut $Dependent = core::ptr::addr_of_mut!((*joined_ptr.as_ptr()).dependent);
+                let owner_ptr: *mut $Owner = joined_ptr.as_ptr().cast::<$Owner>();
+                let dependent_ptr: *mut $Dependent = joined_ptr.as_ptr().cast::<u8>().add(JoinedCell::dependent_offset()).cast::<$Dependent>();
 
                 // Move owner into newly allocated space.
                 owner_ptr.write(owner);
@@ -447,8 +447,8 @@ macro_rules! self_cell {
                     joined_void_ptr
                 );
 
-                let owner_ptr: *mut $Owner = core::ptr::addr_of_mut!((*joined_ptr.as_ptr()).owner);
-                let dependent_ptr: *mut $Dependent = core::ptr::addr_of_mut!((*joined_ptr.as_ptr()).dependent);
+                let owner_ptr: *mut $Owner = joined_ptr.as_ptr().cast::<$Owner>();
+                let dependent_ptr: *mut $Dependent = joined_ptr.as_ptr().cast::<u8>().add(JoinedCell::dependent_offset()).cast::<$Dependent>();
 
                 // Move owner into newly allocated space.
                 owner_ptr.write(owner);

--- a/tests/self_cell.rs
+++ b/tests/self_cell.rs
@@ -834,6 +834,7 @@ fn cell_mem_size() {
 #[test]
 // Not supported by miri isolation.
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(old_rust, ignore)]
 // Closure paths slashes show up as diff error on Windows.
 #[cfg(not(target_os = "windows"))]
 fn invalid_compile() {
@@ -868,6 +869,7 @@ fn try_build_manual(path: &str) {
 #[test]
 // Not supported by miri isolation.
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(old_rust, ignore)]
 fn invalid_compile_manual() {
     try_build_manual("tests/invalid_manual/wrong_covariance");
 }


### PR DESCRIPTION
This restores compatibility with rust versions older Than 1.51. In particular it's now again working with versions of Rust down to 1.42 which is what I'm trying to target (#30).

It's switching the use of `addr_of_mut!` to manually computing the offsets of the `JoinedCell`. It relies on the first member being at offset 0, and the second is calculated accordingly. This also requires the `JoinedCell` to use `repr(C)` but this should be okay.

I wanted to also add a 1.42.0 test run in GitHub to ensure support, but unfortunately the snapshots for the errors changed between recent Rust versions and I with how the tests are set up I need to pick if I want to support newer Rusts or older Rusts. There might be a better way to achieve test coverage by skipping over some of these for 1.42.0 but I am not sure how to accomplish this.

Fixes #30.