### PR TITLE
build: include LICENSE and README in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ categories = ["rust-patterns", "memory-management"]
 include = [
     "src/*.rs",
     "Cargo.toml",
+    "README.md",
+    "LICENSE",
 ]
 
 [dependencies]


### PR DESCRIPTION
Explicitly include LICENSE and README in the crate. The terms of the
Apache-2.0 license require redistributed sources to contain the license
text.