### PR TITLE
Allow mutable access to owner during construction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,13 @@ repository = "https://github.com/Voultapher/self_cell"
 keywords = ["lifetime", "borrowing", "self", "reference", "intrusive"]
 categories = ["rust-patterns", "memory-management"]
 
-include = [
-    "src/*.rs",
-    "Cargo.toml",
-    "README.md",
-    "LICENSE",
-]
+include = ["src/*.rs", "Cargo.toml", "README.md", "LICENSE"]
 
 [dependencies]
-rustversion = { version=">=1", optional=true }
+rustversion = { version = ">=1", optional = true }
 
 [dev-dependencies]
-once_cell = ">=1"
+once_cell = "1.7"
 
 [features]
 # This optional feature lowers the minimum rustc version from 1.51 to 1.36.

--- a/examples/lazy_ast/Cargo.toml
+++ b/examples/lazy_ast/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-self_cell = { path="../../"}
-once_cell = "1.7.2"
+self_cell = { path = "../../" }
+once_cell = "1.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,21 +191,21 @@ pub mod unsafe_self_cell;
 /// ```ignore
 /// fn new(
 ///     owner: $Owner,
-///     dependent_builder: impl for<'a> FnOnce(&'a $Owner) -> $Dependent<'a>
+///     dependent_builder: impl for<'a> FnOnce(&'a mut $Owner) -> $Dependent<'a>
 /// ) -> Self
 /// ```
 ///
 /// ```ignore
 /// fn try_new<Err>(
 ///     owner: $Owner,
-///     dependent_builder: impl for<'a> FnOnce(&'a $Owner) -> Result<$Dependent<'a>, Err>
+///     dependent_builder: impl for<'a> FnOnce(&'a mut $Owner) -> Result<$Dependent<'a>, Err>
 /// ) -> Result<Self, Err>
 /// ```
 ///
 /// ```ignore
 /// fn try_new_or_recover<Err>(
 ///     owner: $Owner,
-///     dependent_builder: impl for<'a> FnOnce(&'a $Owner) -> Result<$Dependent<'a>, Err>
+///     dependent_builder: impl for<'a> FnOnce(&'a mut $Owner) -> Result<$Dependent<'a>, Err>
 /// ) -> Result<Self, ($Owner, Err)>
 /// ```
 ///
@@ -339,7 +339,7 @@ macro_rules! self_cell {
     impl $(<$OwnerLifetime>)? $StructName $(<$OwnerLifetime>)? {
         $Vis fn new(
             owner: $Owner,
-            dependent_builder: impl for<'_q> FnOnce(&'_q $Owner) -> $Dependent<'_q>
+            dependent_builder: impl for<'_q> FnOnce(&'_q mut $Owner) -> $Dependent<'_q>
         ) -> Self {
             use core::ptr::NonNull;
 
@@ -378,7 +378,7 @@ macro_rules! self_cell {
                     $crate::unsafe_self_cell::OwnerAndCellDropGuard::new(joined_ptr);
 
                 // Initialize dependent with owner reference in final place.
-                dependent_ptr.write(dependent_builder(&*owner_ptr));
+                dependent_ptr.write(dependent_builder(&mut *owner_ptr));
                 core::mem::forget(drop_guard);
 
                 Self {
@@ -393,7 +393,7 @@ macro_rules! self_cell {
         $Vis fn try_new<Err>(
             owner: $Owner,
             dependent_builder:
-                impl for<'_q> FnOnce(&'_q $Owner) -> core::result::Result<$Dependent<'_q>, Err>
+                impl for<'_q> FnOnce(&'_q mut $Owner) -> core::result::Result<$Dependent<'_q>, Err>
         ) -> core::result::Result<Self, Err> {
             use core::ptr::NonNull;
 
@@ -421,7 +421,7 @@ macro_rules! self_cell {
                 let mut drop_guard =
                     $crate::unsafe_self_cell::OwnerAndCellDropGuard::new(joined_ptr);
 
-                match dependent_builder(&*owner_ptr) {
+                match dependent_builder(&mut *owner_ptr) {
                     Ok(dependent) => {
                         dependent_ptr.write(dependent);
                         core::mem::forget(drop_guard);
@@ -441,7 +441,7 @@ macro_rules! self_cell {
         $Vis fn try_new_or_recover<Err>(
             owner: $Owner,
             dependent_builder:
-                impl for<'_q> FnOnce(&'_q $Owner) -> core::result::Result<$Dependent<'_q>, Err>
+                impl for<'_q> FnOnce(&'_q mut $Owner) -> core::result::Result<$Dependent<'_q>, Err>
         ) -> core::result::Result<Self, ($Owner, Err)> {
             use core::ptr::NonNull;
 
@@ -469,7 +469,7 @@ macro_rules! self_cell {
                 let mut drop_guard =
                     $crate::unsafe_self_cell::OwnerAndCellDropGuard::new(joined_ptr);
 
-                match dependent_builder(&*owner_ptr) {
+                match dependent_builder(&mut *owner_ptr) {
                     Ok(dependent) => {
                         dependent_ptr.write(dependent);
                         core::mem::forget(drop_guard);


### PR DESCRIPTION
There are cases such as `ZipArchive get_index` that would require mutable access to the owner during construction. Conceptually mutating the owner after creation is unsafe because it may invalidate the dependent. However during construction, no dependent exists yet. So it should be safe to hand a mutable reference into the dependent_build function.