### PR TITLE
Fix "best-effort" typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ support down to rustc version 1.36. However this requires polyfilling std
 library functionality for older rustc with technically UB versions. Testing does
 not show older rustc versions (ab)using this. Use at your own risk.
 
-The minimum versions are a best effor and may change with any new major release.
+The minimum versions are best-effort and may change with any new major release.
 
 ## Contributing
 


### PR DESCRIPTION
"Effort" was missing the letter "t". I've also slightly tweaked the wording in a way that reads better to me, but obviously feel free to change it however you see fit :)

I am a bit confused about the statement in general, though: is MSRV truly best-effort, or is it guaranteed to only change in major versions? Perhaps more clarification would be good.

In any case, this crate is great and I look forward to using it!