### PR TITLE
Use cast instead of transmute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,9 +370,7 @@ macro_rules! self_cell {
 
                 let joined_void_ptr = NonNull::new($crate::alloc::alloc::alloc(layout)).unwrap();
 
-                let mut joined_ptr = core::mem::transmute::<NonNull<u8>, NonNull<JoinedCell>>(
-                    joined_void_ptr
-                );
+                let mut joined_ptr = joined_void_ptr.cast::<JoinedCell>();
 
                 let (owner_ptr, dependent_ptr) = JoinedCell::_field_pointers(joined_ptr.as_ptr());
 
@@ -417,9 +415,7 @@ macro_rules! self_cell {
 
                 let joined_void_ptr = NonNull::new($crate::alloc::alloc::alloc(layout)).unwrap();
 
-                let mut joined_ptr = core::mem::transmute::<NonNull<u8>, NonNull<JoinedCell>>(
-                    joined_void_ptr
-                );
+                let mut joined_ptr = joined_void_ptr.cast::<JoinedCell>();
 
                 let (owner_ptr, dependent_ptr) = JoinedCell::_field_pointers(joined_ptr.as_ptr());
 
@@ -468,9 +464,7 @@ macro_rules! self_cell {
 
                 let joined_void_ptr = NonNull::new($crate::alloc::alloc::alloc(layout)).unwrap();
 
-                let mut joined_ptr = core::mem::transmute::<NonNull<u8>, NonNull<JoinedCell>>(
-                    joined_void_ptr
-                );
+                let mut joined_ptr = joined_void_ptr.cast::<JoinedCell>();
 
                 let (owner_ptr, dependent_ptr) = JoinedCell::_field_pointers(joined_ptr.as_ptr());
 


### PR DESCRIPTION
`NonNull` supports `cast()`, so there's no need for `transmute`.