### PR TITLE
Add support for mut ref dependents

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ impl Debug for NewStructName { ... }
 
 Self-referential structs are currently not supported with safe vanilla Rust. The
 only reasonable safe alternative is to expect the user to juggle 2 separate data
-structures which is a mess. The library solution ouroboros is really expensive
-to compile due to its use of procedural macros.
+structures which is a mess. The library solution ouroboros is expensive to
+compile due to its use of procedural macros.
 
 This alternative is `no_std`, uses no proc-macros, some self contained unsafe
 and works on stable Rust, and is miri tested. With a total of less than 300

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "fallible_dependent_construction",
     "lazy_ast",
     "owner_with_lifetime",
+    "mut_ref_to_owner_in_builder",
 ]

--- a/examples/REAME.md
+++ b/examples/REAME.md
@@ -6,5 +6,7 @@ The advanced examples:
 
 - [How to build a lazy AST with self_cell](lazy_ast)
 
+- [How to handle dependents that take a mutable reference](mut_ref_to_owner_in_builder)
+
 - [How to use an owner type with lifetime](owner_with_lifetime)
 

--- a/examples/mut_ref_to_owner_in_builder/Cargo.toml
+++ b/examples/mut_ref_to_owner_in_builder/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mut_ref_to_owner_in_builder"
+name = "owner_with_lifetime"
 version = "0.1.0"
 authors = ["Lukas Bergdoll <lukas.bergdoll@gmail.com>"]
 edition = "2018"
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-self_cell = { path = "../../" }
+self_cell = { path="../../"}

--- a/examples/mut_ref_to_owner_in_builder/README.md
+++ b/examples/mut_ref_to_owner_in_builder/README.md
@@ -1,0 +1,14 @@
+# `mut_ref_to_owner_in_builder` Example
+
+This example shows how to handle dependent types that want to reference the
+owner by `&mut`. This works by using the wrapper type `MutBorrow` around the
+owner type. This allows us to call `borrow_mut` in the builder function. This
+example also shows how to recover the owner value if desired.
+
+Run this example with `cargo run`, it should output:
+
+```
+dependent before pop: abc
+dependent after pop: ab
+recovered owner: ab
+```

--- a/examples/mut_ref_to_owner_in_builder/src/main.rs
+++ b/examples/mut_ref_to_owner_in_builder/src/main.rs
@@ -1,0 +1,25 @@
+use self_cell::{self_cell, MutBorrow};
+
+type MutStringRef<'a> = &'a mut String;
+
+self_cell!(
+    struct MutStringCell {
+        owner: MutBorrow<String>,
+
+        #[covariant]
+        dependent: MutStringRef,
+    }
+);
+
+fn main() {
+    let mut cell = MutStringCell::new(MutBorrow::new("abc".into()), |owner| owner.borrow_mut());
+
+    cell.with_dependent_mut(|_owner, dependent| {
+        println!("dependent before pop: {}", dependent);
+        dependent.pop();
+        println!("dependent after pop: {}", dependent);
+    });
+
+    let recovered_owner: String = cell.into_owner().into_inner();
+    println!("recovered owner: {}", recovered_owner);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,7 +699,7 @@ macro_rules! _impl_automatic_derive {
 #[macro_export]
 macro_rules! _mut_borrow_unlock {
     ($owner_ptr:expr, $Owner:ty) => {{
-        let wrapper = std::mem::transmute::<
+        let wrapper = ::core::mem::transmute::<
             &mut $Owner,
             &mut $crate::unsafe_self_cell::MutBorrowSpecWrapper<$Owner>,
         >(&mut *$owner_ptr);
@@ -713,7 +713,7 @@ macro_rules! _mut_borrow_unlock {
 #[macro_export]
 macro_rules! _mut_borrow_lock {
     ($owner_ptr:expr, $Owner:ty) => {{
-        let wrapper = std::mem::transmute::<
+        let wrapper = ::core::mem::transmute::<
             &$Owner,
             &$crate::unsafe_self_cell::MutBorrowSpecWrapper<$Owner>,
         >(&*$owner_ptr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,9 +354,6 @@ macro_rules! self_cell {
         ) -> Self {
             use ::core::ptr::NonNull;
 
-            #[allow(unused)]
-            use $crate::unsafe_self_cell::MutBorrowDefaultTrait;
-
             unsafe {
                 // All this has to happen here, because there is not good way
                 // of passing the appropriate logic into UnsafeSelfCell::new
@@ -393,8 +390,6 @@ macro_rules! self_cell {
                 dependent_ptr.write(dependent_builder(&*owner_ptr));
                 ::core::mem::forget(drop_guard);
 
-                $crate::_mut_borrow_lock!(owner_ptr, $Owner);
-
                 Self {
                     unsafe_self_cell: $crate::unsafe_self_cell::UnsafeSelfCell::new(
                         joined_void_ptr,
@@ -413,9 +408,6 @@ macro_rules! self_cell {
                 impl for<'_q> ::core::ops::FnOnce(&'_q $Owner) -> ::core::result::Result<$Dependent<'_q>, Err>
         ) -> ::core::result::Result<Self, Err> {
             use ::core::ptr::NonNull;
-
-            #[allow(unused)]
-            use $crate::unsafe_self_cell::MutBorrowDefaultTrait;
 
             unsafe {
                 // See fn new for more explanation.
@@ -443,8 +435,6 @@ macro_rules! self_cell {
                     ::core::result::Result::Ok(dependent) => {
                         dependent_ptr.write(dependent);
                         ::core::mem::forget(drop_guard);
-
-                        $crate::_mut_borrow_lock!(owner_ptr, $Owner);
 
                         ::core::result::Result::Ok(Self {
                             unsafe_self_cell: $crate::unsafe_self_cell::UnsafeSelfCell::new(
@@ -468,9 +458,6 @@ macro_rules! self_cell {
         ) -> ::core::result::Result<Self, ($Owner, Err)> {
             use ::core::ptr::NonNull;
 
-            #[allow(unused)]
-            use $crate::unsafe_self_cell::MutBorrowDefaultTrait;
-
             unsafe {
                 // See fn new for more explanation.
 
@@ -497,8 +484,6 @@ macro_rules! self_cell {
                     ::core::result::Result::Ok(dependent) => {
                         dependent_ptr.write(dependent);
                         ::core::mem::forget(drop_guard);
-
-                        $crate::_mut_borrow_lock!(owner_ptr, $Owner);
 
                         ::core::result::Result::Ok(Self {
                             unsafe_self_cell: $crate::unsafe_self_cell::UnsafeSelfCell::new(
@@ -687,20 +672,6 @@ macro_rules! _impl_automatic_derive {
             stringify!($x)
         ));
     };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _mut_borrow_lock {
-    ($owner_ptr:expr, $Owner:ty) => {{
-        let wrapper = ::core::mem::transmute::<
-            &$Owner,
-            &$crate::unsafe_self_cell::MutBorrowSpecWrapper<$Owner>,
-        >(&*$owner_ptr);
-
-        // If `T` is `MutBorrow` will call `lock`, otherwise a no-op.
-        wrapper.lock();
-    }};
 }
 
 pub use unsafe_self_cell::MutBorrow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,8 +385,6 @@ macro_rules! self_cell {
                 // Move owner into newly allocated space.
                 owner_ptr.write(owner);
 
-                $crate::_mut_borrow_unlock!(owner_ptr, $Owner);
-
                 // Drop guard that cleans up should building the dependent panic.
                 let drop_guard =
                     $crate::unsafe_self_cell::OwnerAndCellDropGuard::new(joined_ptr);
@@ -436,8 +434,6 @@ macro_rules! self_cell {
 
                 // Move owner into newly allocated space.
                 owner_ptr.write(owner);
-
-                $crate::_mut_borrow_unlock!(owner_ptr, $Owner);
 
                 // Drop guard that cleans up should building the dependent panic.
                 let mut drop_guard =
@@ -492,8 +488,6 @@ macro_rules! self_cell {
 
                 // Move owner into newly allocated space.
                 owner_ptr.write(owner);
-
-                $crate::_mut_borrow_unlock!(owner_ptr, $Owner);
 
                 // Drop guard that cleans up should building the dependent panic.
                 let mut drop_guard =
@@ -693,20 +687,6 @@ macro_rules! _impl_automatic_derive {
             stringify!($x)
         ));
     };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _mut_borrow_unlock {
-    ($owner_ptr:expr, $Owner:ty) => {{
-        let wrapper = ::core::mem::transmute::<
-            &mut $Owner,
-            &mut $crate::unsafe_self_cell::MutBorrowSpecWrapper<$Owner>,
-        >(&mut *$owner_ptr);
-
-        // If `T` is `MutBorrow` will call `unlock`, otherwise a no-op.
-        wrapper.unlock();
-    }};
 }
 
 #[doc(hidden)]

--- a/tests-extra/Cargo.lock
+++ b/tests-extra/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.0.1"
+version = "1.0.4"
 
 [[package]]
 name = "serde"

--- a/tests/self_cell.rs
+++ b/tests/self_cell.rs
@@ -783,24 +783,17 @@ fn cell_mem_size() {
 }
 
 #[test]
-#[should_panic]
 fn mut_borrow_new_borrow() {
-    let mut_borrow = MutBorrow::new(45);
-    let _ = mut_borrow.borrow_mut();
+    let mut_borrow = MutBorrow::new("abc".to_string());
+
+    let string_ref: &mut String = mut_borrow.borrow_mut();
+    string_ref.pop();
+    assert_eq!(string_ref, "ab");
 }
 
 #[test]
 fn mut_borrow_mutate() {
-    let mut mut_borrow = MutBorrow::new(45);
-
-    unsafe {
-        let wrapper = std::mem::transmute::<
-            &mut MutBorrow<i32>,
-            &mut self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
-        >(&mut mut_borrow);
-
-        wrapper.unlock();
-    }
+    let mut_borrow = MutBorrow::new(45);
 
     let mut_ref: &mut i32 = mut_borrow.borrow_mut();
 
@@ -812,16 +805,7 @@ fn mut_borrow_mutate() {
 #[test]
 #[should_panic]
 fn mut_borrow_double_borrow() {
-    let mut mut_borrow = MutBorrow::new(45);
-
-    unsafe {
-        let wrapper = std::mem::transmute::<
-            &mut MutBorrow<i32>,
-            &mut self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
-        >(&mut mut_borrow);
-
-        wrapper.unlock();
-    }
+    let mut_borrow = MutBorrow::new(45);
 
     let _mut_ref_a: &mut i32 = mut_borrow.borrow_mut();
     let _mut_ref_b: &mut i32 = mut_borrow.borrow_mut();
@@ -830,16 +814,7 @@ fn mut_borrow_double_borrow() {
 #[test]
 #[should_panic]
 fn mut_borrow_lock_borrow() {
-    let mut mut_borrow = MutBorrow::new(45);
-
-    unsafe {
-        let wrapper = std::mem::transmute::<
-            &mut MutBorrow<i32>,
-            &mut self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
-        >(&mut mut_borrow);
-
-        wrapper.unlock();
-    }
+    let mut_borrow = MutBorrow::new(45);
 
     {
         let wrapper = unsafe {

--- a/tests/self_cell.rs
+++ b/tests/self_cell.rs
@@ -10,7 +10,7 @@ use std::str;
 
 use once_cell::unsync::OnceCell;
 
-use self_cell::self_cell;
+use self_cell::{self_cell, MutBorrow};
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Ast<'input>(pub Vec<&'input str>);
@@ -237,6 +237,7 @@ fn catch_panic_in_from() {
     #[derive(Debug, Clone, PartialEq)]
     struct Owner(String);
 
+    #[allow(dead_code)]
     #[derive(Debug)]
     struct PanicCtor<'a>(&'a i32);
 
@@ -351,6 +352,7 @@ fn drop_order() {
     }
 
     struct Owner(Rc<RefCell<Vec<Dropped>>>);
+    #[allow(dead_code)]
     struct Dependent<'a>(&'a Owner, Rc<RefCell<Vec<Dropped>>>);
 
     impl Drop for Owner {
@@ -688,6 +690,7 @@ fn result_name_hygiene() {
     #[allow(dead_code)]
     type Result<T> = std::result::Result<T, ()>;
 
+    #[allow(dead_code)]
     type VecRef<'a> = &'a Vec<u8>;
 
     self_cell!(
@@ -777,4 +780,217 @@ fn cell_mem_size() {
 
     assert_eq!(size_of::<PackedAstCell>(), size_of::<*const u8>());
     assert_eq!(size_of::<Option<PackedAstCell>>(), size_of::<*const u8>());
+}
+
+#[test]
+#[should_panic]
+fn mut_borrow_new_borrow() {
+    let mut_borrow = MutBorrow::new(45);
+    let _ = mut_borrow.borrow_mut();
+}
+
+#[test]
+fn mut_borrow_mutate() {
+    let mut mut_borrow = MutBorrow::new(45);
+
+    unsafe {
+        let wrapper = std::mem::transmute::<
+            &mut MutBorrow<i32>,
+            &mut self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
+        >(&mut mut_borrow);
+
+        wrapper.unlock();
+    }
+
+    let mut_ref: &mut i32 = mut_borrow.borrow_mut();
+
+    *mut_ref = 789;
+
+    assert_eq!(mut_borrow.into_inner(), 789);
+}
+
+#[test]
+#[should_panic]
+fn mut_borrow_double_borrow() {
+    let mut mut_borrow = MutBorrow::new(45);
+
+    unsafe {
+        let wrapper = std::mem::transmute::<
+            &mut MutBorrow<i32>,
+            &mut self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
+        >(&mut mut_borrow);
+
+        wrapper.unlock();
+    }
+
+    let _mut_ref_a: &mut i32 = mut_borrow.borrow_mut();
+    let _mut_ref_b: &mut i32 = mut_borrow.borrow_mut();
+}
+
+#[test]
+#[should_panic]
+fn mut_borrow_lock_borrow() {
+    let mut mut_borrow = MutBorrow::new(45);
+
+    unsafe {
+        let wrapper = std::mem::transmute::<
+            &mut MutBorrow<i32>,
+            &mut self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
+        >(&mut mut_borrow);
+
+        wrapper.unlock();
+    }
+
+    {
+        let wrapper = unsafe {
+            std::mem::transmute::<
+                &MutBorrow<i32>,
+                &self_cell::unsafe_self_cell::MutBorrowSpecWrapper<MutBorrow<i32>>,
+            >(&mut_borrow)
+        };
+
+        wrapper.lock();
+    }
+
+    let _: &mut i32 = mut_borrow.borrow_mut();
+}
+
+type MutStringRef<'a> = &'a mut String;
+
+self_cell!(
+    struct MutStringCell {
+        owner: MutBorrow<String>,
+
+        #[covariant]
+        dependent: MutStringRef,
+    }
+);
+
+#[test]
+fn mut_borrow_new() {
+    let mut cell = MutStringCell::new(MutBorrow::new("abc".into()), |owner| owner.borrow_mut());
+
+    let _ = cell.borrow_owner();
+
+    assert_eq!(cell.borrow_dependent(), &"abc");
+
+    cell.with_dependent(|_owner, dependent| {
+        assert_eq!(dependent, &"abc");
+    });
+
+    cell.with_dependent_mut(|_owner, dependent| {
+        assert_eq!(dependent, &"abc");
+        dependent.pop();
+        assert_eq!(dependent, &"ab");
+    });
+
+    assert_eq!(cell.into_owner().into_inner(), "ab");
+}
+
+#[test]
+fn mut_borrow_try_new() {
+    let mut cell = MutStringCell::try_new(
+        MutBorrow::new("abc".into()),
+        |owner| -> Result<&mut String, ()> { std::result::Result::Ok(owner.borrow_mut()) },
+    )
+    .unwrap();
+
+    cell.with_dependent_mut(|_owner, dependent| {
+        dependent.pop();
+    });
+
+    assert_eq!(cell.into_owner().into_inner(), "ab");
+
+    let res = MutStringCell::try_new(MutBorrow::new("wxyz".into()), |_owner| {
+        std::result::Result::Err(678)
+    });
+    let err: i32 = match res {
+        std::result::Result::Ok(_) => {
+            unreachable!()
+        }
+        std::result::Result::Err(err) => err,
+    };
+
+    assert_eq!(err, 678);
+}
+
+#[test]
+fn mut_borrow_try_new_or_recover() {
+    let mut cell = MutStringCell::try_new_or_recover(
+        MutBorrow::new("abc".into()),
+        |owner| -> Result<&mut String, ()> { std::result::Result::Ok(owner.borrow_mut()) },
+    )
+    .map_err(|(_owner, err)| err)
+    .unwrap();
+
+    cell.with_dependent_mut(|_owner, dependent| {
+        dependent.pop();
+    });
+
+    assert_eq!(cell.into_owner().into_inner(), "ab");
+
+    let res = MutStringCell::try_new_or_recover(MutBorrow::new("wxyz".into()), |_owner| {
+        std::result::Result::Err(678)
+    });
+    let (owner, err): (MutBorrow<String>, i32) = match res {
+        std::result::Result::Ok(_) => {
+            unreachable!()
+        }
+        std::result::Result::Err(err) => err,
+    };
+
+    assert_eq!(owner.into_inner(), "wxyz");
+    assert_eq!(err, 678);
+}
+
+type MutBorrowStringRef<'a> = &'a MutBorrow<String>;
+
+self_cell!(
+    struct MutStringFullBorrowCell {
+        owner: MutBorrow<String>,
+
+        #[covariant]
+        dependent: MutBorrowStringRef,
+    }
+);
+
+#[test]
+#[should_panic]
+fn mut_borrow_new_borrow_mut() {
+    let cell = MutStringCell::new(MutBorrow::new("abc".into()), |owner| owner.borrow_mut());
+
+    cell.borrow_owner().borrow_mut();
+}
+
+#[test]
+#[should_panic]
+fn mut_borrow_new_late_borrow_mut() {
+    let cell = MutStringFullBorrowCell::new(MutBorrow::new("abc".into()), |owner| owner);
+
+    cell.borrow_owner().borrow_mut();
+}
+
+#[test]
+#[should_panic]
+fn mut_borrow_try_new_late_borrow_mut() {
+    let cell = MutStringFullBorrowCell::try_new(
+        MutBorrow::new("abc".into()),
+        |owner| -> Result<MutBorrowStringRef, ()> { std::result::Result::Ok(owner) },
+    )
+    .unwrap();
+
+    cell.borrow_owner().borrow_mut();
+}
+
+#[test]
+#[should_panic]
+fn mut_borrow_try_new_or_recover_late_borrow_mut() {
+    let cell = MutStringFullBorrowCell::try_new_or_recover(
+        MutBorrow::new("abc".into()),
+        |owner| -> Result<MutBorrowStringRef, ()> { std::result::Result::Ok(owner) },
+    )
+    .map_err(|(_owner, err)| err)
+    .unwrap();
+
+    cell.borrow_owner().borrow_mut();
 }


### PR DESCRIPTION
This has feature that has been requested multiple times by users. ~This also closes the last AFAIK feature gap to ouroboros.~ ouroboros supports async builders.

Fixes https://github.com/Voultapher/self_cell/issues/59 and https://github.com/Voultapher/self_cell/pull/36.