### PR TITLE
Reinclude license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Voultapher/self_cell"
 keywords = ["lifetime", "borrowing", "self", "reference", "intrusive"]
 categories = ["rust-patterns", "memory-management"]
 
-include = ["src/*.rs", "Cargo.toml", "README.md", "LICENSE"]
+include = ["src/*.rs", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 rustversion = { version = ">=1", optional = true }


### PR DESCRIPTION
In 1.2.1 the project was relicensed to Apache-2.0 OR GPL-2.0-only, and now ships two license texts.

However, `Cargo.toml` is still set to only include `LICENSE` - broaden it to `LICENSE*` so the two license files are actually included as intended.

```
$ cargo package --allow-dirty --list | grep LICENSE
LICENSE-APACHE
LICENSE-GPLv2
```